### PR TITLE
fix(security): use Web Crypto API in middleware for Edge runtime compat

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,15 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createHmac } from 'crypto';
 
 const SESSION_SECRET = process.env.SESSION_SECRET ?? 'change-this-secret';
 const COOKIE_NAME = 'sd_sess';
 const PUBLIC_PATHS = ['/login', '/auth'];
 
-function expectedToken(): string {
-  return createHmac('sha256', SESSION_SECRET).update('authenticated').digest('hex');
+async function computeToken(): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(SESSION_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode('authenticated'));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
 }
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
@@ -17,8 +27,11 @@ export function middleware(request: NextRequest) {
   }
 
   const cookie = request.cookies.get(COOKIE_NAME)?.value;
-  if (cookie && cookie === expectedToken()) {
-    return NextResponse.next();
+  if (cookie) {
+    const expected = await computeToken();
+    if (cookie === expected) {
+      return NextResponse.next();
+    }
   }
 
   const loginUrl = new URL('/login', request.url);


### PR DESCRIPTION
Node.js crypto (createHmac) is not available in the Edge runtime where Next.js middleware runs by default. Switching to the Web Crypto API (crypto.subtle) which is natively supported in Edge.

https://claude.ai/code/session_011HFQg1V9fAqsksVpsUCSn2