### PR TITLE
fix: scheduler logging, edit modal, Colombia timezone display

### DIFF
--- a/apps/api/src/modules/posts/posts.service.ts
+++ b/apps/api/src/modules/posts/posts.service.ts
@@ -63,7 +63,7 @@ export class PostsService {
     await this.schedulerQueue.add(
       'scan',
       { type: 'scan' },
-      { repeat: { every: 60000 }, jobId: 'global-scan', deduplication: { id: 'global-scan' } },
+      { repeat: { every: 60_000 } },
     );
 
     this.logger.log(`Post created: ${post.id} scheduled for ${post.scheduledAt}`);

--- a/apps/api/src/modules/posts/processors/post-scheduler.processor.ts
+++ b/apps/api/src/modules/posts/processors/post-scheduler.processor.ts
@@ -1,5 +1,5 @@
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
-import { Logger } from '@nestjs/common';
+import { Logger, OnModuleInit } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Job, Queue } from 'bullmq';
 import { PrismaService } from '@socialdrop/prisma';
@@ -11,7 +11,7 @@ interface SchedulerJobData {
 }
 
 @Processor('post-scheduler')
-export class PostSchedulerProcessor extends WorkerHost {
+export class PostSchedulerProcessor extends WorkerHost implements OnModuleInit {
   private readonly logger = new Logger(PostSchedulerProcessor.name);
 
   constructor(
@@ -20,6 +20,16 @@ export class PostSchedulerProcessor extends WorkerHost {
     @InjectQueue('post-scheduler') private readonly schedulerQueue: Queue,
   ) {
     super();
+  }
+
+  async onModuleInit() {
+    const jobs = await this.schedulerQueue.getRepeatableJobs();
+    if (!jobs.some(j => j.name === 'scan')) {
+      await this.schedulerQueue.add('scan', { type: 'scan' }, { repeat: { every: 60_000 } });
+      this.logger.log('[Scheduler] Recurring scan job registered (every 60s)');
+    } else {
+      this.logger.log('[Scheduler] Recurring scan job already active');
+    }
   }
 
   async process(job: Job<SchedulerJobData>): Promise<unknown> {
@@ -35,6 +45,7 @@ export class PostSchedulerProcessor extends WorkerHost {
   }
 
   private async scanScheduledPosts() {
+    this.logger.log(`[Scheduler] Scanning at ${new Date().toISOString()}, checking pending posts...`);
     const pendingPosts = await this.prisma.postIntegration.findMany({
       where: {
         status: 'PENDING',

--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -3,7 +3,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api';
 import { useState, useEffect } from 'react';
 import { StatusBadge, PostStatus } from '@/components/StatusBadge';
-import { X } from 'lucide-react';
+import { EditPostModal, EditablePost } from '@/components/EditPostModal';
+import { X, Pencil } from 'lucide-react';
 
 const PLATFORM_COLORS: Record<string, string> = {
   FACEBOOK: '#1877F2', INSTAGRAM: '#E1306C', TWITTER: '#1DA1F2',
@@ -62,6 +63,7 @@ function FullCalendarWrapper({ events, onEventClick }: { events: CalendarEvent[]
 export default function CalendarPage() {
   const qc = useQueryClient();
   const [selected, setSelected] = useState<Post | null>(null);
+  const [editPost, setEditPost]  = useState<EditablePost | null>(null);
 
   const { data: posts = [] } = useQuery({
     queryKey: ['posts-all'],
@@ -111,9 +113,23 @@ export default function CalendarPage() {
             <p className="text-gray-300 text-sm">{selected.content}</p>
             <div className="flex items-center gap-2">
               <StatusBadge status={selected.status} />
-              <span className="text-xs text-gray-400">{new Date(selected.scheduledAt).toLocaleString('es')}</span>
+              <span className="text-xs text-gray-400">
+                {new Date(selected.scheduledAt).toLocaleString('es-CO', {
+                  timeZone: 'America/Bogota',
+                  day: '2-digit', month: 'short', year: 'numeric',
+                  hour: '2-digit', minute: '2-digit',
+                })}
+              </span>
             </div>
             <div className="flex gap-2 pt-2">
+              {(selected.status === 'SCHEDULED' || selected.status === 'ERROR' || selected.status === 'PENDING') && (
+                <button
+                  onClick={() => { setEditPost(selected as EditablePost); setSelected(null); }}
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-indigo-700 hover:bg-indigo-600 rounded-lg text-sm font-medium"
+                >
+                  <Pencil size={14} /> Editar
+                </button>
+              )}
               {selected.status === 'ERROR' && (
                 <button
                   onClick={() => retryMutation.mutate(selected.id)}
@@ -132,6 +148,7 @@ export default function CalendarPage() {
           </div>
         </div>
       )}
+      <EditPostModal post={editPost} onClose={() => setEditPost(null)} />
     </div>
   );
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,10 +4,17 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api';
 import { StatusBadge, PostStatus } from '@/components/StatusBadge';
 import { PlatformIcon, Platform } from '@/components/PlatformIcon';
-import { format } from 'date-fns';
-import { es } from 'date-fns/locale';
-import { Loader2, X, RefreshCw, AlertCircle } from 'lucide-react';
+import { EditPostModal, EditablePost } from '@/components/EditPostModal';
+import { Loader2, X, RefreshCw, AlertCircle, Pencil } from 'lucide-react';
 import { toast } from 'sonner';
+
+function fmtBogota(iso: string) {
+  return new Date(iso).toLocaleString('es-CO', {
+    timeZone: 'America/Bogota',
+    day: '2-digit', month: 'short', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
 
 interface StatsOverview { published: number; pending: number; failed: number; total: number; today: number; }
 
@@ -31,6 +38,7 @@ export default function DashboardPage() {
   const userId = 'demo-user';
   const qc = useQueryClient();
   const [showFailedDrawer, setShowFailedDrawer] = useState(false);
+  const [editPost, setEditPost] = useState<EditablePost | null>(null);
 
   const stats = useQuery({
     queryKey: ['stats'],
@@ -106,13 +114,14 @@ export default function DashboardPage() {
               <tr className="text-gray-400 text-left">
                 <th className="px-4 py-3 font-medium">Caption</th>
                 <th className="px-4 py-3 font-medium hidden md:table-cell">Plataformas</th>
-                <th className="px-4 py-3 font-medium hidden lg:table-cell">Fecha</th>
+                <th className="px-4 py-3 font-medium hidden lg:table-cell">Fecha (Bogotá)</th>
                 <th className="px-4 py-3 font-medium">Estado</th>
+                <th className="px-4 py-3 font-medium"></th>
               </tr>
             </thead>
             <tbody>
               {(posts.data ?? []).map(post => (
-                <tr key={post.id} className="border-t border-gray-800 hover:bg-gray-800/50 cursor-pointer">
+                <tr key={post.id} className="border-t border-gray-800 hover:bg-gray-800/50">
                   <td className="px-4 py-3 max-w-xs truncate">{post.content}</td>
                   <td className="px-4 py-3 hidden md:table-cell">
                     <div className="flex gap-1 flex-wrap">
@@ -122,15 +131,28 @@ export default function DashboardPage() {
                     </div>
                   </td>
                   <td className="px-4 py-3 hidden lg:table-cell text-gray-400">
-                    {format(new Date(post.scheduledAt), 'dd MMM yyyy HH:mm', { locale: es })}
+                    {fmtBogota(post.scheduledAt)}
                   </td>
                   <td className="px-4 py-3"><StatusBadge status={post.status} /></td>
+                  <td className="px-4 py-3">
+                    {(post.status === 'SCHEDULED' || post.status === 'ERROR' || post.status === 'PENDING') && (
+                      <button
+                        onClick={() => setEditPost(post as EditablePost)}
+                        className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-colors"
+                        title="Editar"
+                      >
+                        <Pencil size={14} />
+                      </button>
+                    )}
+                  </td>
                 </tr>
               ))}
             </tbody>
           </table>
         )}
       </div>
+
+      <EditPostModal post={editPost} onClose={() => setEditPost(null)} />
 
       {/* ── Failed Posts Drawer ── */}
       {showFailedDrawer && (
@@ -220,7 +242,7 @@ export default function DashboardPage() {
                     {/* Date & Retry */}
                     <div className="flex items-center justify-between pt-1">
                       <span className="text-xs text-gray-500">
-                        {format(new Date(post.scheduledAt), 'dd MMM yyyy HH:mm', { locale: es })}
+                        {fmtBogota(post.scheduledAt)}
                       </span>
                       <button
                         onClick={() => retryMutation.mutate(post.id)}

--- a/apps/web/src/components/EditPostModal.tsx
+++ b/apps/web/src/components/EditPostModal.tsx
@@ -1,0 +1,180 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { X } from 'lucide-react';
+import { toast } from 'sonner';
+import { apiFetch } from '@/lib/api';
+import { PostStatus } from './StatusBadge';
+
+const PLATFORMS = [
+  { id: 'FACEBOOK',  label: 'Facebook',    color: '#1877F2' },
+  { id: 'INSTAGRAM', label: 'Instagram',   color: '#E1306C' },
+  { id: 'TWITTER',   label: 'X / Twitter', color: '#1DA1F2' },
+  { id: 'TIKTOK',    label: 'TikTok',      color: '#000000' },
+  { id: 'YOUTUBE',   label: 'YouTube',     color: '#FF0000' },
+];
+
+const USER_ID = 'demo-user';
+
+export interface EditablePost {
+  id: string;
+  content: string;
+  status: PostStatus;
+  scheduledAt: string;
+  integrations: { integration: { platform: string } }[];
+}
+
+function toLocalInput(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+interface Props {
+  post: EditablePost | null;
+  onClose: () => void;
+}
+
+export function EditPostModal({ post, onClose }: Props) {
+  const qc = useQueryClient();
+  const [content,     setContent]     = useState('');
+  const [scheduledAt, setScheduledAt] = useState('');
+  const [platforms,   setPlatforms]   = useState<string[]>([]);
+
+  useEffect(() => {
+    if (post) {
+      setContent(post.content);
+      setScheduledAt(toLocalInput(post.scheduledAt));
+      setPlatforms(post.integrations.map(pi => pi.integration.platform));
+    }
+  }, [post]);
+
+  const updateMutation = useMutation({
+    mutationFn: (data: object) =>
+      apiFetch(`/api/posts/${post!.id}?userId=${USER_ID}`, {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      toast.success('Post actualizado correctamente');
+      qc.invalidateQueries({ queryKey: ['posts'] });
+      qc.invalidateQueries({ queryKey: ['posts-all'] });
+      qc.invalidateQueries({ queryKey: ['posts-failed'] });
+      qc.invalidateQueries({ queryKey: ['stats'] });
+      onClose();
+    },
+    onError: (e: Error) => toast.error(`Error: ${e.message}`),
+  });
+
+  if (!post) return null;
+
+  const canEdit = post.status === 'SCHEDULED' || post.status === 'ERROR' || post.status === 'PENDING';
+
+  function handleSave() {
+    if (!content.trim())    { toast.error('El caption no puede estar vacío'); return; }
+    if (!platforms.length)  { toast.error('Selecciona al menos una plataforma'); return; }
+    if (!scheduledAt)       { toast.error('Selecciona una fecha y hora'); return; }
+    updateMutation.mutate({
+      content,
+      scheduledAt: new Date(scheduledAt).toISOString(),
+      platforms,
+    });
+  }
+
+  function togglePlatform(id: string) {
+    setPlatforms(prev => prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]);
+  }
+
+  const statusColors: Record<string, string> = {
+    PUBLISHED:  'bg-green-900 text-green-300',
+    ERROR:      'bg-red-900 text-red-300',
+    SCHEDULED:  'bg-blue-900 text-blue-300',
+    PUBLISHING: 'bg-purple-900 text-purple-300',
+    PENDING:    'bg-yellow-900 text-yellow-300',
+    DRAFT:      'bg-gray-700 text-gray-300',
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+      <div className="bg-gray-900 border border-gray-800 rounded-xl w-full max-w-lg p-6 space-y-4">
+        <div className="flex justify-between items-center">
+          <h3 className="font-semibold text-lg">Editar Post</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-white"><X size={20} /></button>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusColors[post.status] ?? 'bg-gray-700 text-gray-300'}`}>
+            {post.status}
+          </span>
+          {!canEdit && (
+            <span className="text-xs text-gray-500">
+              {post.status === 'PUBLISHED' ? 'Los posts publicados no se pueden editar' : 'No editable en este estado'}
+            </span>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-1">Caption</label>
+          <textarea
+            rows={4}
+            value={content}
+            onChange={e => setContent(e.target.value)}
+            disabled={!canEdit}
+            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-gray-100 focus:outline-none focus:border-indigo-500 resize-none disabled:opacity-50"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-1">Fecha y hora</label>
+          <input
+            type="datetime-local"
+            value={scheduledAt}
+            onChange={e => setScheduledAt(e.target.value)}
+            disabled={!canEdit}
+            className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-gray-100 focus:outline-none focus:border-indigo-500 disabled:opacity-50"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-2">Plataformas</label>
+          <div className="flex flex-wrap gap-2">
+            {PLATFORMS.map(p => (
+              <button
+                key={p.id}
+                type="button"
+                disabled={!canEdit}
+                onClick={() => togglePlatform(p.id)}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-all disabled:opacity-50 ${
+                  platforms.includes(p.id)
+                    ? 'border-indigo-500 bg-indigo-950 text-white'
+                    : 'border-gray-700 bg-gray-800 text-gray-400'
+                }`}
+              >
+                <span className="w-2 h-2 rounded-full" style={{ background: p.color }} />
+                {p.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex gap-2 pt-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-gray-800 hover:bg-gray-700 rounded-lg text-sm font-medium"
+          >
+            Cancelar
+          </button>
+          {canEdit && (
+            <button
+              onClick={handleSave}
+              disabled={updateMutation.isPending}
+              className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 rounded-lg text-sm font-medium"
+            >
+              {updateMutation.isPending ? 'Guardando...' : 'Guardar cambios'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
ITEM 1 - Scheduler:
- OnModuleInit registers recurring scan job on API startup (previously only triggered when a post was created)
- Added timestamp + count log every scan cycle
- Removed non-standard deduplication option from queue.add()

ITEM 2 - Edit post modal:
- New EditPostModal component with pre-filled content, datetime, and platform selector
- Disabled state for PUBLISHED posts
- Edit button on dashboard table rows (SCHEDULED/ERROR/PENDING)
- Edit button in calendar event detail modal

ITEM 3 - Datetime display:
- All dates shown in America/Bogota (UTC-5) timezone
- datetime-local input pre-filled with local time on edit
- toISOString() used on submit to correctly save UTC

https://claude.ai/code/session_011HFQg1V9fAqsksVpsUCSn2