### PR TITLE
fix(api): remove unused imports and fix unused variable in stats service

### DIFF
--- a/apps/api/src/modules/brand/brand.controller.ts
+++ b/apps/api/src/modules/brand/brand.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Post, Body, Query, HttpException, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
-import { BrandService, BrandProfileDto } from './brand.service.js';
+import { BrandService } from './brand.service.js';
+import type { BrandProfileDto } from './brand.service.js';
 
 @ApiTags('brand')
 @Controller('brand')

--- a/apps/api/src/modules/integrations/integrations.controller.ts
+++ b/apps/api/src/modules/integrations/integrations.controller.ts
@@ -1,7 +1,7 @@
 import {
-  Controller, Get, Post, Delete, Query, Param, Res, HttpException, HttpStatus,
+  Controller, Get, Delete, Query, Param, Res, HttpException, HttpStatus,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import type { Response } from 'express';
 import { PrismaService } from '@socialdrop/prisma';
 import { IntegrationManager } from '@socialdrop/integrations';

--- a/apps/api/src/modules/media/media.controller.ts
+++ b/apps/api/src/modules/media/media.controller.ts
@@ -1,6 +1,6 @@
 import {
   Controller, Post, Delete, Param, Query, UseInterceptors, UploadedFile,
-  HttpException, HttpStatus, Get,
+  HttpException, HttpStatus,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';

--- a/apps/api/src/modules/stats/stats.service.ts
+++ b/apps/api/src/modules/stats/stats.service.ts
@@ -31,14 +31,6 @@ export class StatsService {
   }
 
   async getByPlatform(userId: string) {
-    const results = await this.prisma.postIntegration.groupBy({
-      by: ['status'],
-      where: {
-        integration: { userId },
-      },
-      _count: { _all: true },
-    });
-
     const byPlatform = await this.prisma.integration.findMany({
       where: { userId },
       include: {


### PR DESCRIPTION
## Summary
- Remove unused `Post` import in `integrations.controller.ts`
- Remove unused `ApiResponse` import in `integrations.controller.ts`
- Remove unused `Get` import in `media.controller.ts`
- Remove unused `results` variable in `stats.service.ts`
- Fix `BrandProfileDto` import to use `import type` in `brand.controller.ts`

`pnpm nx build api` passes with 0 errors.

https://claude.ai/code/session_011HFQg1V9fAqsksVpsUCSn2