### PR TITLE
feat(dashboard): add KPI endpoint with engagement, reach and success …

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,12 @@
       "runtimeArgs": ["next", "dev", "--port", "3000"],
       "cwd": "apps/web",
       "port": 3000
+    },
+    {
+      "name": "api",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["nx", "serve", "api"],
+      "port": 3333
     }
   ]
 }

--- a/apps/api/src/modules/stats/stats.controller.ts
+++ b/apps/api/src/modules/stats/stats.controller.ts
@@ -22,4 +22,13 @@ export class StatsController {
     if (!userId) throw new HttpException('userId is required', HttpStatus.BAD_REQUEST);
     return this.statsService.getByPlatform(userId);
   }
+
+  @Get('dashboard')
+  @ApiOperation({ summary: 'Get creator dashboard KPIs: followers, engagement, reach, publish success rate' })
+  @ApiQuery({ name: 'userId', required: true })
+  @ApiQuery({ name: 'period', required: false, description: '7d | 14d | 30d | 90d (default 7d)' })
+  dashboard(@Query('userId') userId: string, @Query('period') period?: string) {
+    if (!userId) throw new HttpException('userId is required', HttpStatus.BAD_REQUEST);
+    return this.statsService.getDashboard(userId, period);
+  }
 }

--- a/apps/api/src/modules/stats/stats.service.ts
+++ b/apps/api/src/modules/stats/stats.service.ts
@@ -1,9 +1,24 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '@socialdrop/prisma';
+import Redis from 'ioredis';
+
+const DASHBOARD_CACHE_TTL_SECONDS = 300;
 
 @Injectable()
 export class StatsService {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly redis: Redis;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    config: ConfigService,
+  ) {
+    this.redis = new Redis({
+      host: config.get<string>('redis.host', 'localhost'),
+      port: config.get<number>('redis.port', 6379),
+      lazyConnect: true,
+    });
+  }
 
   async getOverview(userId: string) {
     const todayStart = new Date();
@@ -47,5 +62,96 @@ export class StatsService {
       pending: int.posts.filter((p) => p.status === 'PENDING').length,
       failed: int.posts.filter((p) => p.status === 'ERROR').length,
     }));
+  }
+
+  async getDashboard(userId: string, period = '7d') {
+    const cacheKey = `stats:dashboard:${userId}:${period}`;
+    try {
+      const cached = await this.redis.get(cacheKey);
+      if (cached) return JSON.parse(cached);
+    } catch {
+      // Non-fatal: if Redis is down, fall through to a fresh computation
+    }
+
+    const days = period === '14d' ? 14 : period === '90d' ? 90 : period === '30d' ? 30 : 7;
+    const now = new Date();
+    const periodStart = new Date(now);
+    periodStart.setDate(periodStart.getDate() - days);
+    const prevPeriodStart = new Date(now);
+    prevPeriodStart.setDate(prevPeriodStart.getDate() - days * 2);
+
+    // ERROR posts never get publishedAt set (see post-scheduler.processor.ts), so publishSuccessRate
+    // and postsThisWeek/postsLastWeek fall back to updatedAt for them to still land in the right window.
+    const publishedOrErroredIn = (from: Date, to: Date) => ({
+      OR: [
+        { publishedAt: { gte: from, lt: to } },
+        { status: 'ERROR' as const, publishedAt: null, updatedAt: { gte: from, lt: to } },
+      ],
+    });
+
+    const [
+      latestFollowers,
+      baselineFollowers,
+      currentAnalytics,
+      prevAnalytics,
+      postsThisWeek,
+      postsLastWeek,
+      publishedInPeriod,
+      erroredInPeriod,
+    ] = await Promise.all([
+      this.prisma.platformMetrics.findMany({
+        where: { userId },
+        distinct: ['platform'],
+        orderBy: { recordedAt: 'desc' },
+      }),
+      this.prisma.platformMetrics.findMany({
+        where: { userId, recordedAt: { lte: periodStart } },
+        distinct: ['platform'],
+        orderBy: { recordedAt: 'desc' },
+      }),
+      this.prisma.postAnalytics.aggregate({
+        where: { userId, publishedAt: { gte: periodStart, lte: now } },
+        _sum: { reach: true, impressions: true },
+        _avg: { engagementRate: true },
+      }),
+      this.prisma.postAnalytics.aggregate({
+        where: { userId, publishedAt: { gte: prevPeriodStart, lt: periodStart } },
+        _avg: { engagementRate: true },
+      }),
+      this.prisma.post.count({ where: { userId, ...publishedOrErroredIn(periodStart, now) } }),
+      this.prisma.post.count({ where: { userId, ...publishedOrErroredIn(prevPeriodStart, periodStart) } }),
+      this.prisma.post.count({ where: { userId, status: 'PUBLISHED', ...publishedOrErroredIn(periodStart, now) } }),
+      this.prisma.post.count({ where: { userId, status: 'ERROR', ...publishedOrErroredIn(periodStart, now) } }),
+    ]);
+
+    const followers = latestFollowers.reduce((s, m) => s + m.followersCount, 0);
+    const baselineTotal = baselineFollowers.reduce((s, m) => s + m.followersCount, 0);
+    const followersDeltaWoW = baselineTotal > 0
+      ? +(((followers - baselineTotal) / baselineTotal) * 100).toFixed(2)
+      : 0;
+
+    const successDenominator = publishedInPeriod + erroredInPeriod;
+    const publishSuccessRate = successDenominator > 0
+      ? +((publishedInPeriod / successDenominator) * 100).toFixed(2)
+      : 0;
+
+    const result = {
+      followers,
+      followersDeltaWoW,
+      avgEngagementRate: currentAnalytics._avg.engagementRate ?? 0,
+      totalReach: currentAnalytics._sum.reach ?? 0,
+      totalImpressions: currentAnalytics._sum.impressions ?? 0,
+      publishSuccessRate,
+      postsThisWeek,
+      postsLastWeek,
+    };
+
+    try {
+      await this.redis.set(cacheKey, JSON.stringify(result), 'EX', DASHBOARD_CACHE_TTL_SECONDS);
+    } catch {
+      // Non-fatal: caching is best-effort
+    }
+
+    return result;
   }
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -18,6 +18,17 @@ function fmtBogota(iso: string) {
 
 interface StatsOverview { published: number; pending: number; failed: number; total: number; today: number; }
 
+interface DashboardKpis {
+  followers: number;
+  followersDeltaWoW: number;
+  avgEngagementRate: number;
+  totalReach: number;
+  totalImpressions: number;
+  publishSuccessRate: number;
+  postsThisWeek: number;
+  postsLastWeek: number;
+}
+
 interface PostIntegrationDetail {
   id: string;
   status: string;
@@ -45,6 +56,11 @@ export default function DashboardPage() {
     queryFn: () => apiFetch<StatsOverview>(`/api/stats/overview?userId=${userId}`),
   });
 
+  const kpis = useQuery({
+    queryKey: ['stats-dashboard'],
+    queryFn: () => apiFetch<DashboardKpis>(`/api/stats/dashboard?userId=${userId}&period=7d`),
+  });
+
   const posts = useQuery({
     queryKey: ['posts'],
     queryFn: () => apiFetch<Post[]>(`/api/posts?userId=${userId}&limit=20`),
@@ -67,11 +83,19 @@ export default function DashboardPage() {
     onError: (e: Error) => toast.error(`Error: ${e.message}`),
   });
 
-  const STAT_CARDS = [
+  const postsDeltaWoW = kpis.data && kpis.data.postsLastWeek > 0
+    ? +(((kpis.data.postsThisWeek - kpis.data.postsLastWeek) / kpis.data.postsLastWeek) * 100).toFixed(1)
+    : null;
+
+  const STAT_CARDS: { label: string; value: number | string; color: string; clickable: boolean; delta?: number | null }[] = [
     { label: 'Publicados hoy', value: stats.data?.today ?? 0, color: 'text-green-400', clickable: false },
     { label: 'Programados', value: stats.data?.pending ?? 0, color: 'text-blue-400', clickable: false },
     { label: 'Fallidos', value: stats.data?.failed ?? 0, color: 'text-red-400', clickable: true },
     { label: 'Total', value: stats.data?.total ?? 0, color: 'text-gray-300', clickable: false },
+    { label: 'Seguidores', value: kpis.data?.followers ?? 0, color: 'text-indigo-400', clickable: false, delta: kpis.data?.followersDeltaWoW },
+    { label: 'Engagement', value: `${(kpis.data?.avgEngagementRate ?? 0).toFixed(2)}%`, color: 'text-pink-400', clickable: false },
+    { label: 'Alcance', value: kpis.data?.totalReach ?? 0, color: 'text-yellow-400', clickable: false },
+    { label: 'Tasa de éxito', value: `${(kpis.data?.publishSuccessRate ?? 0).toFixed(1)}%`, color: 'text-teal-400', clickable: false, delta: postsDeltaWoW },
   ];
 
   return (
@@ -80,7 +104,7 @@ export default function DashboardPage() {
 
       {/* Stat cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        {STAT_CARDS.map(({ label, value, color, clickable }) => (
+        {STAT_CARDS.map(({ label, value, color, clickable, delta }) => (
           <div
             key={label}
             data-testid={`stat-card-${label.toLowerCase().replace(/\s+/g, '-')}`}
@@ -91,9 +115,14 @@ export default function DashboardPage() {
           >
             <p className="text-sm text-gray-400">{label}</p>
             <p className={`text-3xl font-bold mt-1 ${color}`}>
-              {stats.isLoading ? <Loader2 className="animate-spin" size={24} /> : value}
+              {(stats.isLoading || kpis.isLoading) ? <Loader2 className="animate-spin" size={24} /> : value}
             </p>
-            {clickable && value > 0 && (
+            {delta !== undefined && delta !== null && (
+              <p className={`text-xs mt-1 ${delta >= 0 ? 'text-green-400/80' : 'text-red-400/80'}`}>
+                {delta >= 0 ? '↑' : '↓'} {Math.abs(delta)}% vs semana anterior
+              </p>
+            )}
+            {clickable && typeof value === 'number' && value > 0 && (
               <p className="text-xs text-red-400/70 mt-1">Click para ver detalles →</p>
             )}
           </div>


### PR DESCRIPTION
…rate

Implementa docs/prs/PR-01.md. Nuevo GET /api/stats/dashboard?period=7d en StatsService devuelve followers, followersDeltaWoW, avgEngagementRate, totalReach, totalImpressions, publishSuccessRate, postsThisWeek y postsLastWeek en queries agregadas (sin N+1), cacheado 5 min en Redis. El dashboard ahora muestra 8 KPIs con delta WoW donde aplica.