### PR TITLE
fix(stats): rewrite getByPlatform with grouped queries and add platfo…

### DIFF
--- a/apps/api/src/modules/stats/stats.service.ts
+++ b/apps/api/src/modules/stats/stats.service.ts
@@ -46,22 +46,51 @@ export class StatsService {
   }
 
   async getByPlatform(userId: string) {
-    const byPlatform = await this.prisma.integration.findMany({
+    const integrations = await this.prisma.integration.findMany({
       where: { userId },
-      include: {
-        posts: {
-          select: { status: true },
-        },
-      },
+      select: { id: true, platform: true },
     });
+    if (integrations.length === 0) return [];
 
-    return byPlatform.map((int) => ({
-      platform: int.platform,
-      accountName: int.accountName,
-      published: int.posts.filter((p) => p.status === 'PUBLISHED').length,
-      pending: int.posts.filter((p) => p.status === 'PENDING').length,
-      failed: int.posts.filter((p) => p.status === 'ERROR').length,
-    }));
+    const [statusCounts, engagementByPlatform] = await Promise.all([
+      this.prisma.postIntegration.groupBy({
+        by: ['integrationId', 'status'],
+        where: { integrationId: { in: integrations.map((i) => i.id) } },
+        _count: { _all: true },
+      }),
+      this.prisma.postAnalytics.groupBy({
+        by: ['platform'],
+        where: { userId },
+        _avg: { engagementRate: true },
+      }),
+    ]);
+
+    const countsByIntegration = new Map<string, Map<string, number>>();
+    for (const row of statusCounts) {
+      if (!countsByIntegration.has(row.integrationId)) countsByIntegration.set(row.integrationId, new Map());
+      countsByIntegration.get(row.integrationId)!.set(row.status, row._count._all);
+    }
+    const engagementMap = new Map(engagementByPlatform.map((e) => [e.platform, e._avg.engagementRate ?? 0]));
+
+    const byPlatform = new Map<string, { platform: string; published: number; pending: number; failed: number; avgEngagementRate: number }>();
+    for (const integ of integrations) {
+      const entry = byPlatform.get(integ.platform) ?? {
+        platform: integ.platform,
+        published: 0,
+        pending: 0,
+        failed: 0,
+        avgEngagementRate: engagementMap.get(integ.platform) ?? 0,
+      };
+      const counts = countsByIntegration.get(integ.id);
+      if (counts) {
+        entry.published += counts.get('PUBLISHED') ?? 0;
+        entry.pending += counts.get('PENDING') ?? 0;
+        entry.failed += counts.get('ERROR') ?? 0;
+      }
+      byPlatform.set(integ.platform, entry);
+    }
+
+    return [...byPlatform.values()];
   }
 
   async getDashboard(userId: string, period = '7d') {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,6 +5,7 @@ import { apiFetch } from '@/lib/api';
 import { StatusBadge, PostStatus } from '@/components/StatusBadge';
 import { PlatformIcon, Platform } from '@/components/PlatformIcon';
 import { EditPostModal, EditablePost } from '@/components/EditPostModal';
+import { PlatformBreakdownChart, PlatformStat } from '@/components/PlatformBreakdownChart';
 import { Loader2, X, RefreshCw, AlertCircle, Pencil } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -59,6 +60,11 @@ export default function DashboardPage() {
   const kpis = useQuery({
     queryKey: ['stats-dashboard'],
     queryFn: () => apiFetch<DashboardKpis>(`/api/stats/dashboard?userId=${userId}&period=7d`),
+  });
+
+  const byPlatform = useQuery({
+    queryKey: ['stats-by-platform'],
+    queryFn: () => apiFetch<PlatformStat[]>(`/api/stats/by-platform?userId=${userId}`),
   });
 
   const posts = useQuery({
@@ -128,6 +134,8 @@ export default function DashboardPage() {
           </div>
         ))}
       </div>
+
+      {!byPlatform.isLoading && <PlatformBreakdownChart data={byPlatform.data ?? []} />}
 
       {/* Recent posts table */}
       <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">

--- a/apps/web/src/components/PlatformBreakdownChart.tsx
+++ b/apps/web/src/components/PlatformBreakdownChart.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend, LabelList } from 'recharts';
+import { useTheme } from '@/components/ThemeProvider';
+
+export interface PlatformStat {
+  platform: string;
+  published: number;
+  pending: number;
+  failed: number;
+  avgEngagementRate: number;
+}
+
+export function PlatformBreakdownChart({ data }: { data: PlatformStat[] }) {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+  const gridStroke = isDark ? '#374151' : '#f3f4f6';
+  const tickStyle = { fontSize: 11, fill: isDark ? '#9ca3af' : '#6b7280' };
+  const tooltipStyle = isDark
+    ? { fontSize: 12, borderRadius: 8, backgroundColor: '#1f2937', color: '#f9fafb', border: '1px solid #374151' }
+    : { fontSize: 12, borderRadius: 8, backgroundColor: '#ffffff', color: '#374151', border: 'none' };
+
+  if (data.length === 0) {
+    return (
+      <div className="bg-gray-900 border border-gray-800 rounded-xl p-8 text-center text-gray-500 text-sm">
+        No hay datos por plataforma todavía
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+        <h3 className="text-sm font-semibold text-gray-300 mb-3">Posts por plataforma</h3>
+        <ResponsiveContainer width="100%" height={220}>
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
+            <XAxis dataKey="platform" tick={tickStyle} />
+            <YAxis tick={tickStyle} width={30} allowDecimals={false} />
+            <Tooltip contentStyle={tooltipStyle} />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <Bar dataKey="published" fill="#6366f1" radius={[4, 4, 0, 0]} name="Publicados" />
+            <Bar dataKey="pending" fill="#f59e0b" radius={[4, 4, 0, 0]} name="Pendientes" />
+            <Bar dataKey="failed" fill="#ef4444" radius={[4, 4, 0, 0]} name="Fallidos" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+        <h3 className="text-sm font-semibold text-gray-300 mb-3">Engagement promedio por plataforma</h3>
+        <ResponsiveContainer width="100%" height={220}>
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
+            <XAxis dataKey="platform" tick={tickStyle} />
+            <YAxis tick={tickStyle} width={40} unit="%" />
+            <Tooltip contentStyle={tooltipStyle} formatter={(v) => `${Number(v).toFixed(2)}%`} />
+            <Bar dataKey="avgEngagementRate" fill="#14b8a6" radius={[4, 4, 0, 0]} name="Engagement %">
+              <LabelList dataKey="avgEngagementRate" position="top" formatter={(v) => `${Number(v).toFixed(1)}%`} style={{ fontSize: 11, fill: isDark ? '#d1d5db' : '#374151' }} />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
…rm chart

Implementa docs/prs/PR-02.md. getByPlatform ya no carga todos los posts de cada integracion en memoria: usa postIntegration.groupBy + postAnalytics.groupBy en paralelo y agrega por plataforma (incluye avgEngagementRate). Nuevo PlatformBreakdownChart en el dashboard con barras apiladas por estado y engagement promedio, con etiquetas directas y soporte dark/light via ThemeProvider.