### PR TITLE
perf(queue): reduce findNextFreeSlot from O(days*slots) to 1 query

### DIFF
--- a/apps/api/src/modules/queue/queue.service.spec.ts
+++ b/apps/api/src/modules/queue/queue.service.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import 'reflect-metadata';
+
+vi.mock('@nestjs/common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nestjs/common')>();
+  return {
+    ...actual,
+    Logger: class {
+      log = vi.fn();
+      warn = vi.fn();
+      error = vi.fn();
+    },
+  };
+});
+
+import { QueueService } from './queue.service.js';
+
+const mockPrisma = {
+  queueSlot: { findMany: vi.fn() },
+  post: { findMany: vi.fn() },
+};
+
+describe('QueueService.findNextFreeSlot', () => {
+  let service: QueueService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new QueueService(mockPrisma as any);
+  });
+
+  it('returns the first candidate slot when there is no conflict', async () => {
+    mockPrisma.queueSlot.findMany.mockResolvedValue([
+      { id: 's1', dayOfWeek: 1, hour: 10, minute: 0 },
+    ]);
+    mockPrisma.post.findMany.mockResolvedValue([]);
+
+    const from = new Date(2026, 0, 5); // Monday, local time
+    const result = await service.findNextFreeSlot('u1', 'INSTAGRAM' as any, from);
+
+    expect(result.slot.id).toBe('s1');
+    expect(mockPrisma.post.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips a slot within 30 minutes of an already-scheduled post', async () => {
+    mockPrisma.queueSlot.findMany.mockResolvedValue([
+      { id: 's1', dayOfWeek: 1, hour: 10, minute: 0 },
+      { id: 's2', dayOfWeek: 1, hour: 14, minute: 0 },
+    ]);
+    // Conflict 15 min after the first candidate (Mon 10:00 local)
+    mockPrisma.post.findMany.mockResolvedValue([
+      { scheduledAt: new Date(2026, 0, 5, 10, 15, 0) },
+    ]);
+
+    const from = new Date(2026, 0, 5);
+    const result = await service.findNextFreeSlot('u1', 'INSTAGRAM' as any, from);
+
+    expect(result.slot.id).toBe('s2');
+    // Still exactly one aggregated query regardless of how many candidates were checked
+    expect(mockPrisma.post.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a candidate more than 30 minutes away from a scheduled post', async () => {
+    mockPrisma.queueSlot.findMany.mockResolvedValue([
+      { id: 's1', dayOfWeek: 1, hour: 10, minute: 0 },
+    ]);
+    mockPrisma.post.findMany.mockResolvedValue([
+      { scheduledAt: new Date(2026, 0, 5, 11, 0, 0) },
+    ]);
+
+    const from = new Date(2026, 0, 5);
+    const result = await service.findNextFreeSlot('u1', 'INSTAGRAM' as any, from);
+
+    expect(result.slot.id).toBe('s1');
+  });
+});

--- a/apps/api/src/modules/queue/queue.service.ts
+++ b/apps/api/src/modules/queue/queue.service.ts
@@ -67,6 +67,24 @@ export class QueueService {
       );
     }
 
+    const horizonEnd = new Date(from);
+    horizonEnd.setDate(horizonEnd.getDate() + SEARCH_HORIZON_DAYS);
+
+    const scheduledPosts = await this.prisma.post.findMany({
+      where: {
+        userId,
+        scheduledAt: { gte: from, lte: horizonEnd },
+        integrations: { some: { integration: { platform } } },
+      },
+      select: { scheduledAt: true },
+    });
+    const scheduledTimes = scheduledPosts.map((p) => p.scheduledAt.getTime());
+
+    const hasConflict = (candidateTime: number) =>
+      scheduledTimes.some(
+        (t) => Math.abs(t - candidateTime) <= COLLISION_MINUTES * 60_000,
+      );
+
     for (let dayOffset = 0; dayOffset < SEARCH_HORIZON_DAYS; dayOffset++) {
       const day = new Date(from);
       day.setDate(day.getDate() + dayOffset);
@@ -80,20 +98,7 @@ export class QueueService {
 
         if (candidate.getTime() <= from.getTime()) continue;
 
-        const windowStart = new Date(candidate.getTime() - COLLISION_MINUTES * 60_000);
-        const windowEnd = new Date(candidate.getTime() + COLLISION_MINUTES * 60_000);
-
-        const conflict = await this.prisma.post.findFirst({
-          where: {
-            userId,
-            scheduledAt: { gte: windowStart, lte: windowEnd },
-            integrations: {
-              some: { integration: { platform } },
-            },
-          },
-        });
-
-        if (!conflict) {
+        if (!hasConflict(candidate.getTime())) {
           return { slot, date: candidate };
         }
       }


### PR DESCRIPTION
Implementa docs/prs/PR-09.md. Carga una sola vez los posts programados del usuario+plataforma en la ventana de 14 dias y detecta colisiones (+-30 min) en memoria contra los candidatos, en vez de un post.findFirst por cada combinacion dia x slot. Agrega queue.service.spec.ts cubriendo el mismo comportamiento de colision.