### PR TITLE
fix(queue): prune completed/failed BullMQ jobs, add retry backoff def…

### DIFF
--- a/apps/api/src/modules/posts/posts.module.ts
+++ b/apps/api/src/modules/posts/posts.module.ts
@@ -8,7 +8,15 @@ import { DebugModule } from '../debug/debug.module.js';
 
 @Module({
   imports: [
-    BullModule.registerQueue({ name: 'post-scheduler' }),
+    BullModule.registerQueue({
+      name: 'post-scheduler',
+      defaultJobOptions: {
+        removeOnComplete: 1000,
+        removeOnFail: 5000,
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 30_000 },
+      },
+    }),
     IntegrationsModule,
     DebugModule,
   ],


### PR DESCRIPTION
…aults

Implementa la parte de codigo de docs/prs/PR-08.md. defaultJobOptions en el registro de la cola post-scheduler: removeOnComplete 1000, removeOnFail 5000, attempts 3, backoff exponencial 30s. Verificado que el 'publish' processor no depende del attempts nativo de BullMQ (usa su propio retryCount en DB y nunca re-lanza el error), asi que este cambio no altera la logica de reintento existente, solo poda jobs acumulados.

PENDIENTE DE APROBACION MANUAL: mover la cola BullMQ a una instancia/DB de Redis dedicada con `noeviction` en docker-compose.yml (actualmente comparte Redis con allkeys-lru + maxmemory 256mb) -- no se toco docker-compose.yml en este PR.