### PR TITLE
feat(ops): add PostgreSQL backup/restore scripts and docs

### DIFF
--- a/docs/backups.md
+++ b/docs/backups.md
@@ -1,0 +1,45 @@
+# Backups de PostgreSQL
+
+## Backup diario (off-site)
+
+`scripts/backup-db.sh` hace `pg_dump -Fc` de la base de datos y lo sube a un
+remote de `rclone` (R2/S3/B2, lo que esté configurado). Requiere:
+
+- `DATABASE_URL` — ya está en el `.env` del proyecto.
+- `BACKUP_REMOTE` — remote:path de rclone, ej. `r2:socialdrop-backups/postgres`.
+- `rclone` configurado en el host (`rclone config`) con las credenciales del
+  bucket destino — **pendiente de configurar en el VPS**, no incluido en este PR.
+
+Retención por defecto: 30 días (local y remoto), configurable con
+`BACKUP_RETENTION_DAYS`.
+
+**Pendiente de aprobación manual:** wiring del cron (crontab del host o
+servicio `backup` en `docker-compose.yml`) y las credenciales reales del
+bucket — no se tocó `docker-compose.yml` en este PR.
+
+## Restaurar un backup
+
+```bash
+DATABASE_URL="postgres://user:pass@host:5432/staging_db" \
+  ./scripts/restore-db.sh /ruta/al/socialdrop-2026-07-10T03-00-00Z.dump
+
+# o directo desde el remote:
+DATABASE_URL="postgres://user:pass@host:5432/staging_db" \
+  ./scripts/restore-db.sh r2:socialdrop-backups/postgres/socialdrop-2026-07-10T03-00-00Z.dump
+```
+
+**Siempre restaura primero contra una base de staging/vacía**, nunca
+directo contra producción — el script usa `pg_restore --clean`, que
+elimina objetos existentes antes de recrearlos.
+
+Este procedimiento aún no se ha ejecutado contra un dump real en este
+entorno (no hay credenciales de backup ni una base de staging disponibles
+aquí) — verifícalo una vez tengas el primer backup real antes de confiar
+en él para producción.
+
+## Alertas de fallo
+
+El script sale con código distinto de cero si `pg_dump`, `rclone copy` o el
+prune fallan. Conéctalo a tu wrapper de alertas (cron `MAILTO`,
+healthchecks.io, o el canal de alertas de PR #23) revisando `$?` tras la
+ejecución — el wiring de la alerta en sí queda pendiente.

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Daily off-site PostgreSQL backup for SocialDrop.
+#
+# Usage: ./scripts/backup-db.sh
+#
+# Required env vars:
+#   DATABASE_URL          Postgres connection string (already used by the app)
+#   BACKUP_REMOTE         rclone remote + path, e.g. "r2:socialdrop-backups/postgres"
+#                          (configure the "r2" remote once with `rclone config`)
+# Optional env vars:
+#   BACKUP_RETENTION_DAYS Days to keep local + remote dumps before pruning (default: 30)
+#   BACKUP_DIR             Local staging directory (default: /var/backups/socialdrop)
+#
+# Exit code is non-zero on any failure, so this can be wired into an alerting
+# wrapper (cron MAILTO, healthchecks.io curl ping, PR #23's alert channel, etc.)
+# by checking `$?` after invocation.
+
+set -euo pipefail
+
+: "${DATABASE_URL:?DATABASE_URL is required}"
+: "${BACKUP_REMOTE:?BACKUP_REMOTE is required (rclone remote:path)}"
+BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/socialdrop}"
+
+mkdir -p "$BACKUP_DIR"
+
+TIMESTAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+DUMP_FILE="$BACKUP_DIR/socialdrop-$TIMESTAMP.dump"
+
+echo "[backup-db] Dumping database to $DUMP_FILE ..."
+pg_dump -Fc --dbname="$DATABASE_URL" --file="$DUMP_FILE"
+
+echo "[backup-db] Uploading to $BACKUP_REMOTE ..."
+rclone copy "$DUMP_FILE" "$BACKUP_REMOTE" --checksum
+
+echo "[backup-db] Pruning local dumps older than $BACKUP_RETENTION_DAYS days ..."
+find "$BACKUP_DIR" -name 'socialdrop-*.dump' -mtime "+$BACKUP_RETENTION_DAYS" -delete
+
+echo "[backup-db] Pruning remote dumps older than $BACKUP_RETENTION_DAYS days ..."
+rclone delete "$BACKUP_REMOTE" --min-age "${BACKUP_RETENTION_DAYS}d"
+
+echo "[backup-db] Done: $DUMP_FILE"

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Restore a SocialDrop PostgreSQL backup produced by scripts/backup-db.sh.
+#
+# Usage: ./scripts/restore-db.sh <dump-file-or-rclone-path>
+#
+# Examples:
+#   ./scripts/restore-db.sh /var/backups/socialdrop/socialdrop-2026-07-10T03-00-00Z.dump
+#   ./scripts/restore-db.sh r2:socialdrop-backups/postgres/socialdrop-2026-07-10T03-00-00Z.dump
+#
+# Required env vars:
+#   DATABASE_URL   Target Postgres connection string to restore INTO.
+#                  ALWAYS point this at a staging/empty database first — this
+#                  script does not ask for confirmation before dropping objects.
+
+set -euo pipefail
+
+: "${DATABASE_URL:?DATABASE_URL is required}"
+SOURCE="${1:?Usage: restore-db.sh <dump-file-or-rclone-path>}"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+if [[ "$SOURCE" == *:* && "$SOURCE" != /* ]]; then
+  echo "[restore-db] Downloading $SOURCE via rclone ..."
+  rclone copy "$SOURCE" "$WORKDIR"
+  DUMP_FILE="$WORKDIR/$(basename "$SOURCE")"
+else
+  DUMP_FILE="$SOURCE"
+fi
+
+echo "[restore-db] Restoring $DUMP_FILE into \$DATABASE_URL ..."
+pg_restore --clean --if-exists --no-owner --dbname="$DATABASE_URL" "$DUMP_FILE"
+
+echo "[restore-db] Done."


### PR DESCRIPTION
Implementa la parte de codigo de docs/prs/PR-27.md. scripts/backup-db.sh hace pg_dump -Fc diario y lo sube via rclone a un remote S3-compatible (R2/S3/B2), con poda de retencion configurable (default 30 dias) local y remota. scripts/restore-db.sh restaura un dump (local o via rclone) contra un DATABASE_URL destino. docs/backups.md documenta el procedimiento -- NO se ha ejecutado contra un dump real en este entorno (sin credenciales de backup ni DB de staging disponibles aqui).

PENDIENTE DE APROBACION MANUAL: cron/servicio en docker-compose.yml, credenciales reales del bucket de backups, y wiring de alertas de fallo (PR #23) -- no se toco docker-compose.yml en este PR.