### PR TITLE
feat(schema): FK + indices on tenant tables; IG/FB publish by per-int…

### DIFF
--- a/apps/api/src/modules/posts/processors/post-scheduler.processor.ts
+++ b/apps/api/src/modules/posts/processors/post-scheduler.processor.ts
@@ -249,6 +249,7 @@ export class PostSchedulerProcessor extends WorkerHost implements OnModuleInit {
       text: pi.post.content,
       mediaUrls,
       mediaType: pi.post.media[0]?.mediaType as 'VIDEO' | 'IMAGE' | undefined,
+      ...(pi.integration.profileId && { profileId: pi.integration.profileId }),
       ...(postMeta?.instagramType && { instagramType: postMeta.instagramType }),
       ...(postMeta?.youtube && { metadata: { youtube: postMeta.youtube } }),
     };

--- a/libs/integrations/src/providers/facebook.provider.ts
+++ b/libs/integrations/src/providers/facebook.provider.ts
@@ -66,7 +66,7 @@ export class FacebookProvider extends SocialAbstract {
   }
 
   async post(accessToken: string, content: PostContent): Promise<PublishResult> {
-    const pageId = this.config.get<string>('FACEBOOK_PAGE_ID', '');
+    const pageId = content.profileId || this.config.get<string>('FACEBOOK_PAGE_ID', '');
     const delays = [1000, 5000, 15000];
     let lastError: Error = new Error('Unknown error');
 

--- a/libs/integrations/src/providers/instagram.provider.ts
+++ b/libs/integrations/src/providers/instagram.provider.ts
@@ -165,10 +165,10 @@ export class InstagramProvider extends SocialAbstract {
   }
 
   async post(accessToken: string, content: PostContent): Promise<PublishResult> {
-    const igUserId = this.config.get<string>('INSTAGRAM_ACCOUNT_ID', '');
+    const igUserId = content.profileId || this.config.get<string>('INSTAGRAM_ACCOUNT_ID', '');
     this.logger.log(`[Instagram] post() igUserId=${igUserId} mediaUrls=${JSON.stringify(content.mediaUrls)} mediaType=${content.mediaType}`);
 
-    if (!igUserId) throw new Error('[Instagram] INSTAGRAM_ACCOUNT_ID env var is not set');
+    if (!igUserId) throw new Error('[Instagram] No profileId on the integration and INSTAGRAM_ACCOUNT_ID env var is not set');
 
     const delays = [1000, 5000, 15000];
     let lastError: Error = new Error('Unknown error');

--- a/libs/prisma/prisma/migrations/20260710030000_add_tenant_fk_indices/migration.sql
+++ b/libs/prisma/prisma/migrations/20260710030000_add_tenant_fk_indices/migration.sql
@@ -1,0 +1,43 @@
+-- ============================================================
+-- Ensure a "demo-user" User row exists, so any orphaned userId
+-- values in the tables below (rows whose userId doesn't match any
+-- real User — e.g. old @default("demo-user") data written before
+-- real auth existed) have somewhere valid to point before we add
+-- FK constraints. No rows are deleted.
+-- ============================================================
+INSERT INTO "User" ("id", "email", "tokenVersion", "createdAt", "updatedAt")
+VALUES ('demo-user', 'demo-user@socialdrop.local', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON CONFLICT ("id") DO NOTHING;
+
+-- Reassign any orphaned userId to demo-user (safety net; should be a no-op
+-- if every existing userId already has a matching User row).
+UPDATE "ContentItem" SET "userId" = 'demo-user' WHERE "userId" NOT IN (SELECT "id" FROM "User");
+UPDATE "Flow" SET "userId" = 'demo-user' WHERE "userId" NOT IN (SELECT "id" FROM "User");
+UPDATE "Contact" SET "userId" = 'demo-user' WHERE "userId" NOT IN (SELECT "id" FROM "User");
+UPDATE "YoutubeComment" SET "userId" = 'demo-user' WHERE "userId" NOT IN (SELECT "id" FROM "User");
+UPDATE "YoutubeAutoReply" SET "userId" = 'demo-user' WHERE "userId" NOT IN (SELECT "id" FROM "User");
+UPDATE "Competitor" SET "userId" = 'demo-user' WHERE "userId" NOT IN (SELECT "id" FROM "User");
+UPDATE "GeneratedScript" SET "userId" = 'demo-user' WHERE "userId" NOT IN (SELECT "id" FROM "User");
+UPDATE "PlatformMetrics" SET "userId" = 'demo-user' WHERE "userId" NOT IN (SELECT "id" FROM "User");
+UPDATE "PostAnalytics" SET "userId" = 'demo-user' WHERE "userId" NOT IN (SELECT "id" FROM "User");
+
+-- Drop the now-removed @default("demo-user") on the schema side.
+ALTER TABLE "ContentItem" ALTER COLUMN "userId" DROP DEFAULT;
+ALTER TABLE "Flow" ALTER COLUMN "userId" DROP DEFAULT;
+ALTER TABLE "Contact" ALTER COLUMN "userId" DROP DEFAULT;
+ALTER TABLE "YoutubeComment" ALTER COLUMN "userId" DROP DEFAULT;
+ALTER TABLE "YoutubeAutoReply" ALTER COLUMN "userId" DROP DEFAULT;
+
+-- CreateIndex (ContentItem had no userId index before)
+CREATE INDEX "ContentItem_userId_idx" ON "ContentItem"("userId");
+
+-- AddForeignKey (cascade delete — deleting a User removes their tenant data)
+ALTER TABLE "ContentItem" ADD CONSTRAINT "ContentItem_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Flow" ADD CONSTRAINT "Flow_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Contact" ADD CONSTRAINT "Contact_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "YoutubeComment" ADD CONSTRAINT "YoutubeComment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "YoutubeAutoReply" ADD CONSTRAINT "YoutubeAutoReply_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Competitor" ADD CONSTRAINT "Competitor_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "GeneratedScript" ADD CONSTRAINT "GeneratedScript_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PlatformMetrics" ADD CONSTRAINT "PlatformMetrics_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PostAnalytics" ADD CONSTRAINT "PostAnalytics_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/prisma/prisma/schema.prisma
+++ b/libs/prisma/prisma/schema.prisma
@@ -21,6 +21,15 @@ model User {
   driveConfigs          DriveConfig[]
   authTokens            AuthToken[]
   workspaceMemberships  WorkspaceMember[]
+  contentItems          ContentItem[]
+  competitors           Competitor[]
+  flows                 Flow[]
+  contacts              Contact[]
+  youtubeComments       YoutubeComment[]
+  youtubeAutoReplies    YoutubeAutoReply[]
+  generatedScripts      GeneratedScript[]
+  platformMetrics       PlatformMetrics[]
+  postAnalytics         PostAnalytics[]
 }
 
 enum WorkspaceRole {
@@ -223,6 +232,7 @@ model ContentStrategy {
 model PlatformMetrics {
   id               String   @id @default(cuid())
   userId           String
+  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   platform         String
   followersCount   Int
   followingCount   Int?
@@ -240,6 +250,7 @@ model PostAnalytics {
   id             String    @id @default(cuid())
   postId         String?
   userId         String
+  user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   platform       String
   platformPostId String
   caption        String?
@@ -276,9 +287,12 @@ model ContentItem {
   status        PostStatus  @default(DRAFT)
   copyGenerated Boolean     @default(false)
   n8nJobId      String?
-  userId        String      @default("demo-user")
+  userId        String
+  user          User        @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt     DateTime    @default(now())
   updatedAt     DateTime    @updatedAt
+
+  @@index([userId])
 }
 
 model GrowthGoal {
@@ -297,6 +311,7 @@ model GrowthGoal {
 model Competitor {
   id          String               @id @default(cuid())
   userId      String
+  user        User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
   username    String
   platform    String
   displayName String?
@@ -373,7 +388,8 @@ model QueueSlot {
 
 model Flow {
   id         String          @id @default(cuid())
-  userId     String          @default("demo-user")
+  userId     String
+  user       User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   name       String
   platform   String
   trigger    String
@@ -404,7 +420,8 @@ model FlowExecution {
 
 model Contact {
   id        String   @id @default(cuid())
-  userId    String   @default("demo-user")
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   platform  String
   accountId String
   username  String?
@@ -418,7 +435,8 @@ model Contact {
 
 model YoutubeComment {
   id              String    @id @default(cuid())
-  userId          String    @default("demo-user")
+  userId          String
+  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   videoId         String
   videoTitle      String?
   commentId       String    @unique
@@ -441,7 +459,8 @@ model YoutubeComment {
 
 model YoutubeAutoReply {
   id            String   @id @default(cuid())
-  userId        String   @default("demo-user")
+  userId        String
+  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   keyword       String
   replyTemplate String
   isEnabled     Boolean  @default(true)
@@ -454,6 +473,7 @@ model YoutubeAutoReply {
 model GeneratedScript {
   id             String    @id @default(cuid())
   userId         String
+  user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   platform       String
   topic          String
   hook           String

--- a/libs/shared/src/interfaces/social-provider.interface.ts
+++ b/libs/shared/src/interfaces/social-provider.interface.ts
@@ -20,6 +20,8 @@ export interface PostContent {
   mediaType?: MediaType;
   /** Instagram-specific publish type. Defaults to REEL for video, POST for images. */
   instagramType?: 'POST' | 'REEL' | 'STORY';
+  /** Per-integration account id (IG business account id / FB page id). Falls back to a static env var if omitted. */
+  profileId?: string;
   metadata?: {
     youtube?: {
       title?: string;


### PR DESCRIPTION
…egration profileId

Adds `user User @relation(..., onDelete: Cascade)` to ContentItem, Flow, Contact, YoutubeComment, YoutubeAutoReply, Competitor, GeneratedScript, PlatformMetrics, PostAnalytics — deleting a User now cascades to all of their data instead of leaving orphaned rows. Removes @default("demo-user") from the five models that had it.

Migration backfill: before adding each FK, ensures a "demo-user" User row exists and reassigns any userId not matching a real User to it — a safety net so pre-existing rows (written before real auth existed) don't violate the new FK. No rows are deleted. Unverified against a real database (none available in this environment) — review the SQL before running it against production, especially the demo-user reassignment UPDATEs.

Instagram/Facebook publishing now reads the account id from Integration.profileId (via a new PostContent.profileId field threaded through by post-scheduler.processor.ts) instead of the single global INSTAGRAM_ACCOUNT_ID/FACEBOOK_PAGE_ID env vars, falling back to those env vars only if profileId is absent. This is what actually unblocks multi-account IG/FB — previously every workspace's Reels/posts would have published to the same one hardcoded account.

SCOPE NOTE: per the PR-14 addendum, PR-32's full workspaceId migration would have these FKs point at Workspace instead of User. PR-32 in this session only migrated Integration to workspaceId (documented there) — these 9 tables still key by userId, so the FK targets User here, consistent with that earlier scope decision.

Verified: `tsc --noEmit` clean (not just webpack, which transpile-only misses type errors — see the PR-32 workspaceId fix commit for why that matters), `npx nx build api` and `prisma generate` succeed, existing vitest suite (17/17) still passes.