### PR TITLE
feat(usage): monthly quotas on AI-cost endpoints (no Stripe/plan tiers)

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { UsersModule } from '../modules/users/users.module.js';
 import { BrainModule } from '../modules/brain/brain.module.js';
 import { AuthModule } from '../modules/auth/auth.module.js';
 import { WorkspacesModule } from '../modules/workspaces/workspaces.module.js';
+import { UsageModule } from '../modules/usage/usage.module.js';
 import googleConfig from '../config/google.config.js';
 import redisConfig from '../config/redis.config.js';
 
@@ -87,6 +88,7 @@ import redisConfig from '../config/redis.config.js';
     BrainModule,
     AuthModule,
     WorkspacesModule,
+    UsageModule,
   ],
   controllers: [AppController, HealthController],
   providers: [

--- a/apps/api/src/modules/assistant/assistant.controller.ts
+++ b/apps/api/src/modules/assistant/assistant.controller.ts
@@ -1,16 +1,22 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../auth/current-user.decorator.js';
+import { UsageService } from '../usage/usage.service.js';
 import { AssistantService } from './assistant.service.js';
 import { ChatDto } from './dto/chat.dto.js';
 
 @ApiTags('assistant')
 @Controller('assistant')
 export class AssistantController {
-  constructor(private readonly assistantService: AssistantService) {}
+  constructor(
+    private readonly assistantService: AssistantService,
+    private readonly usageService: UsageService,
+  ) {}
 
   @Post('chat')
   @ApiOperation({ summary: 'Send a message to the AI assistant and receive a reply' })
-  async chat(@Body() dto: ChatDto): Promise<{ reply: string }> {
+  async chat(@CurrentUser() userId: string, @Body() dto: ChatDto): Promise<{ reply: string }> {
+    await this.usageService.consume(userId, 'assistant_message');
     const reply = await this.assistantService.chat(dto.message);
     return { reply };
   }

--- a/apps/api/src/modules/assistant/assistant.module.ts
+++ b/apps/api/src/modules/assistant/assistant.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { UsageModule } from '../usage/usage.module.js';
 import { AssistantController } from './assistant.controller.js';
 import { AssistantService } from './assistant.service.js';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, UsageModule],
   controllers: [AssistantController],
   providers: [AssistantService],
   exports: [AssistantService],

--- a/apps/api/src/modules/assistant/assistant.service.ts
+++ b/apps/api/src/modules/assistant/assistant.service.ts
@@ -17,7 +17,7 @@ export class AssistantService {
     this.logger.log(`Assistant chat: "${message.slice(0, 50)}..."`);
 
     const response = await this.client.messages.create({
-      model: 'claude-3-5-haiku-20241022',
+      model: 'claude-haiku-4-5',
       max_tokens: 1024,
       system:
         'You are SocialDrop AI, a social media content assistant. Help users write engaging captions, plan posts, and improve their social media presence. Be concise and creative. Respond in the same language the user writes in.',

--- a/apps/api/src/modules/brain/brain.controller.ts
+++ b/apps/api/src/modules/brain/brain.controller.ts
@@ -14,6 +14,7 @@ import { CurrentUser } from '../auth/current-user.decorator.js';
 import { Queue } from 'bullmq';
 import { BrainService } from './brain.service.js';
 import { TranscriptionService } from './transcription.service.js';
+import { UsageService } from '../usage/usage.service.js';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 
 @ApiTags('brain')
@@ -22,6 +23,7 @@ export class BrainController {
   constructor(
     private readonly brainService: BrainService,
     private readonly transcriptionService: TranscriptionService,
+    private readonly usageService: UsageService,
     @InjectQueue('metrics-collector') private readonly metricsQueue: Queue,
     @InjectQueue('brain-updater') private readonly brainQueue: Queue,
   ) {}
@@ -57,7 +59,8 @@ export class BrainController {
   /** POST /api/content-brain/scripts */
   @Post('scripts')
   @ApiOperation({ summary: 'Save a generated script' })
-  createScript(@CurrentUser() userId: string, @Body() body: any) {
+  async createScript(@CurrentUser() userId: string, @Body() body: any) {
+    await this.usageService.consume(userId, 'script_generation');
     const { userId: _ignored, ...dto } = body;
     return this.brainService.createScript(userId, dto);
   }

--- a/apps/api/src/modules/brain/brain.module.ts
+++ b/apps/api/src/modules/brain/brain.module.ts
@@ -9,12 +9,14 @@ import { MetricsCollectorProcessor } from './metrics-collector.processor.js';
 import { BrainUpdaterProcessor } from './brain-updater.processor.js';
 import { BrainScheduler } from './brain.scheduler.js';
 import { TranscriptionService } from './transcription.service.js';
+import { UsageModule } from '../usage/usage.module.js';
 
 @Module({
   imports: [
     ConfigModule,
     PrismaModule,
     MetricsModule,
+    UsageModule,
     BullModule.registerQueue(
       { name: 'metrics-collector' },
       { name: 'brain-updater' },

--- a/apps/api/src/modules/brain/brain.service.ts
+++ b/apps/api/src/modules/brain/brain.service.ts
@@ -313,7 +313,7 @@ Responde con un JSON con esta estructura exacta:
 
     try {
       const response = await this.anthropic.messages.create({
-        model: 'claude-3-5-haiku-20241022',
+        model: 'claude-haiku-4-5',
         max_tokens: 1024,
         messages: [{ role: 'user', content: prompt }],
       });

--- a/apps/api/src/modules/competitors/competitors.controller.ts
+++ b/apps/api/src/modules/competitors/competitors.controller.ts
@@ -5,6 +5,7 @@ import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
 import { CurrentUser } from '../auth/current-user.decorator.js';
 import { CompetitorsService } from './competitors.service.js';
 import { TranscriptionService } from '../brain/transcription.service.js';
+import { UsageService } from '../usage/usage.service.js';
 
 @ApiTags('competitors')
 @Controller('competitors')
@@ -12,6 +13,7 @@ export class CompetitorsController {
   constructor(
     private readonly competitorsService: CompetitorsService,
     private readonly transcriptionService: TranscriptionService,
+    private readonly usageService: UsageService,
   ) {}
 
   @Get()
@@ -85,7 +87,12 @@ export class CompetitorsController {
 
   @Post(':id/analyze')
   @ApiOperation({ summary: 'Queue per-video transcription + Claude analysis for all reels' })
-  async analyze(@Param('id') id: string, @Body() body: { postIds?: string[] } = {}) {
+  async analyze(
+    @Param('id') id: string,
+    @CurrentUser() userId: string,
+    @Body() body: { postIds?: string[] } = {},
+  ) {
+    await this.usageService.consume(userId, 'competitor_analysis');
     const { queued } = await this.competitorsService.queueVideoAnalysis(id, body.postIds);
     return { queued, message: `Analizando ${queued} videos...` };
   }

--- a/apps/api/src/modules/competitors/competitors.module.ts
+++ b/apps/api/src/modules/competitors/competitors.module.ts
@@ -8,11 +8,13 @@ import {
 } from './competitors.service.js';
 import { CompetitorAnalysisProcessor } from './competitor-analysis.processor.js';
 import { BrainModule } from '../brain/brain.module.js';
+import { UsageModule } from '../usage/usage.module.js';
 
 @Module({
   imports: [
     PrismaModule,
     BrainModule,
+    UsageModule,
     BullModule.registerQueue({ name: COMPETITOR_ANALYSIS_QUEUE }),
   ],
   controllers: [CompetitorsController],

--- a/apps/api/src/modules/usage/usage.controller.ts
+++ b/apps/api/src/modules/usage/usage.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { CurrentUser } from '../auth/current-user.decorator.js';
+import { UsageService } from './usage.service.js';
+
+@ApiTags('usage')
+@Controller('usage')
+export class UsageController {
+  constructor(private readonly usageService: UsageService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Current month usage/quota for the authenticated user' })
+  getUsage(@CurrentUser() userId: string) {
+    return this.usageService.getUsage(userId);
+  }
+}

--- a/apps/api/src/modules/usage/usage.module.ts
+++ b/apps/api/src/modules/usage/usage.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@socialdrop/prisma';
+import { UsageController } from './usage.controller.js';
+import { UsageService } from './usage.service.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [UsageController],
+  providers: [UsageService],
+  exports: [UsageService],
+})
+export class UsageModule {}

--- a/apps/api/src/modules/usage/usage.service.ts
+++ b/apps/api/src/modules/usage/usage.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '@socialdrop/prisma';
+
+export type UsageMetric = 'competitor_analysis' | 'script_generation' | 'assistant_message';
+
+const DEFAULT_LIMITS: Record<UsageMetric, number> = {
+  competitor_analysis: 20,
+  script_generation: 200,
+  assistant_message: 500,
+};
+
+function currentPeriod(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+@Injectable()
+export class UsageService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+  ) {}
+
+  private limitFor(metric: UsageMetric): number {
+    const envKey = `USAGE_LIMIT_${metric.toUpperCase()}`;
+    const raw = this.config.get<string>(envKey);
+    const parsed = raw ? parseInt(raw, 10) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LIMITS[metric];
+  }
+
+  async getUsage(userId: string): Promise<Array<{ metric: string; period: string; count: number; limit: number }>> {
+    const period = currentPeriod();
+    const counters = await this.prisma.usageCounter.findMany({ where: { userId, period } });
+    const byMetric = new Map(counters.map((c) => [c.metric, c.count]));
+    return (Object.keys(DEFAULT_LIMITS) as UsageMetric[]).map((metric) => ({
+      metric,
+      period,
+      count: byMetric.get(metric) ?? 0,
+      limit: this.limitFor(metric),
+    }));
+  }
+
+  /** Throws 403 if the user is at or over quota for this metric this period; otherwise increments and continues. */
+  async consume(userId: string, metric: UsageMetric): Promise<void> {
+    const period = currentPeriod();
+    const limit = this.limitFor(metric);
+
+    const counter = await this.prisma.usageCounter.upsert({
+      where: { userId_metric_period: { userId, metric, period } },
+      update: {},
+      create: { userId, metric, period, count: 0 },
+    });
+
+    if (counter.count >= limit) {
+      throw new ForbiddenException(
+        `Límite mensual alcanzado para ${metric} (${limit}/mes). Se restablece el próximo mes.`,
+      );
+    }
+
+    await this.prisma.usageCounter.update({
+      where: { userId_metric_period: { userId, metric, period } },
+      data: { count: { increment: 1 } },
+    });
+  }
+}

--- a/apps/web/src/app/settings/usage/page.tsx
+++ b/apps/web/src/app/settings/usage/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiFetch } from '@/lib/api';
+
+interface UsageRow {
+  metric: string;
+  period: string;
+  count: number;
+  limit: number;
+}
+
+const METRIC_LABELS: Record<string, string> = {
+  competitor_analysis: 'Análisis de competidores',
+  script_generation: 'Guiones generados',
+  assistant_message: 'Mensajes al asistente',
+};
+
+export default function UsagePage() {
+  const [usage, setUsage] = useState<UsageRow[] | null>(null);
+
+  useEffect(() => {
+    apiFetch<UsageRow[]>('/api/usage').then(setUsage).catch(() => setUsage([]));
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Consumo del mes</h1>
+
+      {!usage ? (
+        <p className="text-sm text-gray-400">Cargando...</p>
+      ) : (
+        <div className="space-y-3">
+          {usage.map((row) => {
+            const pct = Math.min(100, Math.round((row.count / row.limit) * 100));
+            return (
+              <div key={row.metric} className="space-y-1">
+                <div className="flex items-center justify-between text-sm text-gray-700 dark:text-gray-200">
+                  <span>{METRIC_LABELS[row.metric] ?? row.metric}</span>
+                  <span className="text-gray-400">{row.count} / {row.limit}</span>
+                </div>
+                <div className="h-2 rounded-full bg-gray-200 dark:bg-gray-800 overflow-hidden">
+                  <div
+                    className={`h-full rounded-full ${pct >= 100 ? 'bg-red-500' : 'bg-indigo-600'}`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+          <p className="text-xs text-gray-400">Periodo: {usage[0]?.period ?? '—'}. Se reinicia el 1° de cada mes.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -44,6 +44,7 @@ const NAV_SETTINGS = [
   { href: '/settings/brand', label: 'Perfil de marca', icon: Briefcase },
   { href: '/settings/strategy', label: 'Estrategia', icon: BarChart2 },
   { href: '/settings/workspaces', label: 'Workspaces', icon: Users },
+  { href: '/settings/usage', label: 'Consumo', icon: BarChart2 },
 ];
 
 function NavLinks({ onClose }: { onClose: () => void }) {

--- a/libs/prisma/prisma/migrations/20260710040000_add_usage_counter/migration.sql
+++ b/libs/prisma/prisma/migrations/20260710040000_add_usage_counter/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "UsageCounter" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "metric" TEXT NOT NULL,
+    "period" TEXT NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "UsageCounter_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UsageCounter_userId_metric_period_key" ON "UsageCounter"("userId", "metric", "period");
+
+-- CreateIndex
+CREATE INDEX "UsageCounter_userId_period_idx" ON "UsageCounter"("userId", "period");
+
+-- AddForeignKey
+ALTER TABLE "UsageCounter" ADD CONSTRAINT "UsageCounter_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/prisma/prisma/schema.prisma
+++ b/libs/prisma/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   generatedScripts      GeneratedScript[]
   platformMetrics       PlatformMetrics[]
   postAnalytics         PostAnalytics[]
+  usageCounters         UsageCounter[]
 }
 
 enum WorkspaceRole {
@@ -62,6 +63,19 @@ model WorkspaceMember {
 enum AuthTokenType {
   VERIFY_EMAIL
   RESET_PASSWORD
+}
+
+model UsageCounter {
+  id     String @id @default(cuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  metric String
+  /** "YYYY-MM" billing period */
+  period String
+  count  Int    @default(0)
+
+  @@unique([userId, metric, period])
+  @@index([userId, period])
 }
 
 model AuthToken {


### PR DESCRIPTION
New UsageCounter model (userId, metric, period "YYYY-MM", count) + UsageService.consume() — increments and throws 403 once a user hits their monthly limit for a metric, checked before the costly operation runs. Wired into the three endpoints PR-28 calls out: competitor video analysis, script generation (brain scripts save), and assistant chat. Limits are env-configurable (USAGE_LIMIT_<METRIC>) with sane defaults — no plan/Stripe tier logic, consistent with Stripe being out of scope for this session. GET /api/usage exposes current-month consumption; new /settings/usage page renders it as progress bars.

Also fixes a real bug flagged in docs/prs/PR-28.md: both brain.service.ts and assistant.service.ts were calling claude-3-5-haiku-20241022, retired 2026-02-19 — every call has been 404ing and failing silently (brain's catch only logs). Migrated both to claude-haiku-4-5.

Verified: `tsc --noEmit` clean, `npx nx build api`/`build web` succeed, existing vitest suite (17/17) passes.