### PR TITLE
fix(auth): remove insecure fallbacks in PR-31 auth hardening

### DIFF
--- a/apps/api/src/modules/auth/auth.guard.ts
+++ b/apps/api/src/modules/auth/auth.guard.ts
@@ -47,12 +47,6 @@ export class AuthGuard implements CanActivate {
       throw new UnauthorizedException('Invalid or expired token');
     }
 
-    // Dev-mode token issued when APP_PASSWORD isn't configured — no per-user record to check.
-    if (payload.sub === 'user') {
-      req.user = payload;
-      return true;
-    }
-
     const user = await this.prisma.user.findUnique({
       where: { id: payload.sub },
       select: { tokenVersion: true },

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -13,13 +13,19 @@ import { ConsoleMailProvider } from './console-mail.provider.js';
     PrismaModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
-      useFactory: (config: ConfigService): JwtModuleOptions => ({
-        secret: config.get<string>('JWT_SECRET') ?? 'default-jwt-secret-change-in-production',
-        signOptions: {
-          // cast needed: newer @nestjs/jwt types expiresIn as StringValue (ms package)
-          expiresIn: (config.get<string>('JWT_EXPIRY') ?? '7d') as never,
-        },
-      }),
+      useFactory: (config: ConfigService): JwtModuleOptions => {
+        const secret = config.get<string>('JWT_SECRET');
+        if (!secret) {
+          throw new Error('JWT_SECRET is required — set it in the environment before starting the API');
+        }
+        return {
+          secret,
+          signOptions: {
+            // cast needed: newer @nestjs/jwt types expiresIn as StringValue (ms package)
+            expiresIn: (config.get<string>('JWT_EXPIRY') ?? '7d') as never,
+          },
+        };
+      },
       inject: [ConfigService],
     }),
   ],

--- a/apps/api/src/modules/auth/current-user.decorator.ts
+++ b/apps/api/src/modules/auth/current-user.decorator.ts
@@ -1,7 +1,10 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { createParamDecorator, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 
 /** Extracts the authenticated user's id from the JWT set on the request by AuthGuard. */
 export const CurrentUser = createParamDecorator((_data: unknown, ctx: ExecutionContext): string => {
   const req = ctx.switchToHttp().getRequest<{ user?: { sub: string } }>();
-  return req.user?.sub ?? 'demo-user';
+  if (!req.user?.sub) {
+    throw new UnauthorizedException('Authentication required');
+  }
+  return req.user.sub;
 });

--- a/apps/web/e2e/socialdrop.spec.ts
+++ b/apps/web/e2e/socialdrop.spec.ts
@@ -2,10 +2,13 @@ import { test, expect, Page } from '@playwright/test';
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-const PASSWORD = process.env.APP_PASSWORD ?? 'changeme';
+// Requires a seeded user in the target environment (email/password auth — see PR-31).
+const EMAIL = process.env.E2E_TEST_EMAIL ?? 'e2e@socialdrop.test';
+const PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'changeme123';
 
 async function login(page: Page) {
   await page.goto('/login');
+  await page.fill('input[type="email"]', EMAIL);
   await page.fill('input[type="password"]', PASSWORD);
   await page.click('button[type="submit"]');
   await page.waitForURL(/^\/((?!login).)*$/); // Wait until redirected away from /login
@@ -22,9 +25,10 @@ test.describe('Authentication', () => {
 
   test('wrong password shows error', async ({ page }) => {
     await page.goto('/login');
+    await page.fill('input[type="email"]', EMAIL);
     await page.fill('input[type="password"]', 'wrong-password-xyz');
     await page.click('button[type="submit"]');
-    await expect(page.locator('text=Contraseña incorrecta')).toBeVisible();
+    await expect(page.locator('text=Credenciales inválidas')).toBeVisible();
   });
 
   test('correct password redirects to dashboard', async ({ page }) => {


### PR DESCRIPTION
Close the loose ends flagged in PR-31: fail fast if JWT_SECRET is unset instead of using an insecure default, drop the legacy payload.sub === 'user' bypass tied to the old APP_PASSWORD scheme, and make @CurrentUser() throw 401 instead of silently degrading to 'demo-user'. Also updates the e2e login helper to use the real email/password flow.