### PR TITLE
feat(dashboard): motion delta on KPI count-up, bar entrance, heatmap …

### DIFF
--- a/apps/web/src/app/global.css
+++ b/apps/web/src/app/global.css
@@ -36,6 +36,11 @@
 /* Un-layered rules always beat @layer utilities regardless of specificity
    in Tailwind v4's cascade — html/body font-family must live in @layer base
    so the font-body utility class on <body> can actually win. */
+@keyframes heatmap-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 @layer base {
   html {
     -webkit-text-size-adjust: 100%;

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -6,7 +6,7 @@ import { apiFetch } from '@/lib/api';
 import { StatusBadge, PostStatus } from '@/components/StatusBadge';
 import { PlatformChip, Platform } from '@/components/PlatformChip';
 import { EditPostModal, EditablePost } from '@/components/EditPostModal';
-import { Stagger, FadeUp } from '@/components/motion';
+import { Stagger, FadeUp, CountUp } from '@/components/motion';
 import { PlatformBreakdownChart, PlatformStat } from '@/components/PlatformBreakdownChart';
 import { BestTimesHeatmap, BestTimes } from '@/components/BestTimesHeatmap';
 import { OnboardingChecklist } from '@/components/OnboardingChecklist';
@@ -163,12 +163,23 @@ export default function DashboardPage() {
           >
             <p className="text-xs text-ink-muted">{label}</p>
             <p className={`font-mono-nums text-[32px] tabular-nums mt-1 ${warn ? 'text-warning' : 'text-ink'}`}>
-              {(stats.isLoading || kpis.isLoading) ? <Loader2 className="animate-spin" size={24} /> : value}
+              {(stats.isLoading || kpis.isLoading) ? (
+                <Loader2 className="animate-spin" size={24} />
+              ) : typeof value === 'number' ? (
+                <CountUp value={value} />
+              ) : (
+                value
+              )}
             </p>
             {delta !== undefined && delta !== null && (
-              <p className={`text-xs mt-1 font-mono-nums ${delta >= 0 ? 'text-positive' : 'text-warning'}`}>
+              <motion.p
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ delay: 0.15, duration: 0.2 }}
+                className={`text-xs mt-1 font-mono-nums ${delta >= 0 ? 'text-positive' : 'text-warning'}`}
+              >
                 {delta >= 0 ? '▲' : '▼'} {Math.abs(delta)}% vs semana anterior
-              </p>
+              </motion.p>
             )}
             {clickable && typeof value === 'number' && value > 0 && (
               <p className="text-xs text-warning mt-1">Click para ver detalles →</p>

--- a/apps/web/src/components/BestTimesHeatmap.tsx
+++ b/apps/web/src/components/BestTimesHeatmap.tsx
@@ -5,13 +5,12 @@ export interface BestTimes { heatmap: BestTimesCell[]; topSlots: BestTimesCell[]
 
 const DAY_LABELS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
 
-function intensityClass(avg: number, max: number) {
-  if (max <= 0 || avg <= 0) return 'bg-gray-800';
+// Single-tone sequential scale (brand violet, light→dark) — never multicolor.
+function intensityStyle(avg: number, max: number): React.CSSProperties {
+  if (max <= 0 || avg <= 0) return { background: 'var(--color-surface-2)' };
   const pct = avg / max;
-  if (pct > 0.75) return 'bg-indigo-500';
-  if (pct > 0.5) return 'bg-indigo-600/70';
-  if (pct > 0.25) return 'bg-indigo-700/50';
-  return 'bg-indigo-900/40';
+  const opacity = 0.25 + pct * 0.65; // 0.25 → 0.9
+  return { background: `color-mix(in oklab, var(--color-accent) ${Math.round(opacity * 100)}%, var(--color-surface))` };
 }
 
 export function BestTimesHeatmap({ data }: { data: BestTimes | undefined }) {
@@ -20,33 +19,33 @@ export function BestTimesHeatmap({ data }: { data: BestTimes | undefined }) {
   const maxEngagement = Math.max(0, ...heatmap.filter((c) => c.count >= minPostsPerCell).map((c) => c.avgEngagement));
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-      <h3 className="text-sm font-semibold text-gray-300 mb-1">Mejores horas para publicar</h3>
-      <p className="text-xs text-gray-500 mb-3">
+    <div className="bg-surface rounded-card p-4">
+      <h3 className="text-sm font-display font-semibold text-ink mb-1">Mejores horas para publicar</h3>
+      <p className="text-xs text-ink-muted mb-3">
         Basado en engagement histórico (mínimo {minPostsPerCell} posts por franja)
       </p>
 
       {topSlots.length > 0 ? (
         <div className="flex flex-wrap gap-2 mb-4">
           {topSlots.map((slot, i) => (
-            <span key={i} className="text-xs bg-indigo-900/50 text-indigo-300 px-2.5 py-1 rounded-full">
+            <span key={i} className="text-xs bg-accent/15 text-accent px-2.5 py-1 rounded-pill font-mono-nums">
               {DAY_LABELS[slot.dayOfWeek]} {slot.hour}:00 · {slot.avgEngagement}% eng.
             </span>
           ))}
         </div>
       ) : (
-        <p className="text-xs text-gray-500 mb-4">Aún no hay suficientes datos para recomendar franjas.</p>
+        <p className="text-xs text-ink-muted mb-4">Aún no hay suficientes datos para recomendar franjas.</p>
       )}
 
       <div className="overflow-x-auto">
         <div className="inline-grid gap-0.5" style={{ gridTemplateColumns: `2.5rem repeat(24, 1.25rem)` }}>
           <div />
           {Array.from({ length: 24 }, (_, h) => (
-            <div key={h} className="text-[9px] text-gray-500 text-center">{h}</div>
+            <div key={h} className="text-[9px] text-ink-muted text-center font-mono-nums">{h}</div>
           ))}
           {DAY_LABELS.map((label, dayOfWeek) => (
             <>
-              <div key={`${dayOfWeek}-label`} className="text-[10px] text-gray-400 flex items-center">{label}</div>
+              <div key={`${dayOfWeek}-label`} className="text-[10px] text-ink-muted flex items-center">{label}</div>
               {Array.from({ length: 24 }, (_, hour) => {
                 const cell = heatmap.find((c) => c.dayOfWeek === dayOfWeek && c.hour === hour);
                 const eligible = (cell?.count ?? 0) >= minPostsPerCell;
@@ -54,9 +53,11 @@ export function BestTimesHeatmap({ data }: { data: BestTimes | undefined }) {
                   <div
                     key={`${dayOfWeek}-${hour}`}
                     title={cell ? `${label} ${hour}:00 — ${cell.avgEngagement}% eng. (${cell.count} posts)` : ''}
-                    className={`w-5 h-5 rounded-sm flex items-center justify-center text-[7px] text-gray-300 ${
-                      eligible ? intensityClass(cell!.avgEngagement, maxEngagement) : 'bg-gray-800/40'
-                    }`}
+                    className="w-5 h-5 rounded-sm flex items-center justify-center text-[7px] text-ink font-mono-nums motion-safe:animate-[heatmap-fade-in_150ms_ease-out_backwards]"
+                    style={{
+                      ...(eligible ? intensityStyle(cell!.avgEngagement, maxEngagement) : { background: 'var(--color-surface-2)', opacity: 0.4 }),
+                      animationDelay: `${hour * 8}ms`,
+                    }}
                   >
                     {eligible ? Math.round(cell!.avgEngagement) : ''}
                   </div>

--- a/apps/web/src/components/PlatformBreakdownChart.tsx
+++ b/apps/web/src/components/PlatformBreakdownChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend, LabelList } from 'recharts';
-import { useTheme } from '@/components/ThemeProvider';
+import { useReducedMotion } from 'motion/react';
 
 export interface PlatformStat {
   platform: string;
@@ -11,17 +11,15 @@ export interface PlatformStat {
 }
 
 export function PlatformBreakdownChart({ data }: { data: PlatformStat[] }) {
-  const { theme } = useTheme();
-  const isDark = theme === 'dark';
-  const gridStroke = isDark ? '#374151' : '#f3f4f6';
-  const tickStyle = { fontSize: 11, fill: isDark ? '#9ca3af' : '#6b7280' };
-  const tooltipStyle = isDark
-    ? { fontSize: 12, borderRadius: 8, backgroundColor: '#1f2937', color: '#f9fafb', border: '1px solid #374151' }
-    : { fontSize: 12, borderRadius: 8, backgroundColor: '#ffffff', color: '#374151', border: 'none' };
+  const reducedMotion = useReducedMotion();
+  const gridStroke = 'rgba(255,255,255,0.04)';
+  const tickStyle = { fontSize: 11, fill: 'var(--color-ink-muted)' };
+  const tooltipStyle = { fontSize: 12, borderRadius: 8, backgroundColor: 'var(--color-surface-2)', color: 'var(--color-ink)', border: 'none' };
+  const animProps = { isAnimationActive: !reducedMotion, animationDuration: 400, animationEasing: 'ease-out' as const };
 
   if (data.length === 0) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-8 text-center text-gray-500 text-sm">
+      <div className="bg-surface rounded-card p-8 text-center text-ink-muted text-sm">
         No hay datos por plataforma todavía
       </div>
     );
@@ -29,31 +27,31 @@ export function PlatformBreakdownChart({ data }: { data: PlatformStat[] }) {
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-        <h3 className="text-sm font-semibold text-gray-300 mb-3">Posts por plataforma</h3>
+      <div className="bg-surface rounded-card p-4">
+        <h3 className="text-sm font-display font-semibold text-ink mb-3">Posts por plataforma</h3>
         <ResponsiveContainer width="100%" height={220}>
           <BarChart data={data}>
             <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
             <XAxis dataKey="platform" tick={tickStyle} />
             <YAxis tick={tickStyle} width={30} allowDecimals={false} />
             <Tooltip contentStyle={tooltipStyle} />
-            <Legend wrapperStyle={{ fontSize: 12 }} />
-            <Bar dataKey="published" fill="#6366f1" radius={[4, 4, 0, 0]} name="Publicados" />
-            <Bar dataKey="pending" fill="#f59e0b" radius={[4, 4, 0, 0]} name="Pendientes" />
-            <Bar dataKey="failed" fill="#ef4444" radius={[4, 4, 0, 0]} name="Fallidos" />
+            <Legend wrapperStyle={{ fontSize: 12, color: 'var(--color-ink-muted)' }} />
+            <Bar dataKey="published" fill="var(--color-chart-1)" radius={[4, 4, 0, 0]} name="Publicados" {...animProps} animationBegin={0} />
+            <Bar dataKey="pending" fill="var(--color-chart-2)" radius={[4, 4, 0, 0]} name="Pendientes" {...animProps} animationBegin={40} />
+            <Bar dataKey="failed" fill="var(--color-chart-3)" radius={[4, 4, 0, 0]} name="Fallidos" {...animProps} animationBegin={80} />
           </BarChart>
         </ResponsiveContainer>
       </div>
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-        <h3 className="text-sm font-semibold text-gray-300 mb-3">Engagement promedio por plataforma</h3>
+      <div className="bg-surface rounded-card p-4">
+        <h3 className="text-sm font-display font-semibold text-ink mb-3">Engagement promedio por plataforma</h3>
         <ResponsiveContainer width="100%" height={220}>
           <BarChart data={data}>
             <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
             <XAxis dataKey="platform" tick={tickStyle} />
             <YAxis tick={tickStyle} width={40} unit="%" />
             <Tooltip contentStyle={tooltipStyle} formatter={(v) => `${Number(v).toFixed(2)}%`} />
-            <Bar dataKey="avgEngagementRate" fill="#14b8a6" radius={[4, 4, 0, 0]} name="Engagement %">
-              <LabelList dataKey="avgEngagementRate" position="top" formatter={(v) => `${Number(v).toFixed(1)}%`} style={{ fontSize: 11, fill: isDark ? '#d1d5db' : '#374151' }} />
+            <Bar dataKey="avgEngagementRate" fill="var(--color-chart-4)" radius={[4, 4, 0, 0]} name="Engagement %" {...animProps}>
+              <LabelList dataKey="avgEngagementRate" position="top" formatter={(v) => `${Number(v).toFixed(1)}%`} style={{ fontSize: 11, fill: 'var(--color-ink-muted)' }} />
             </Bar>
           </BarChart>
         </ResponsiveContainer>

--- a/apps/web/src/components/motion/CountUp.tsx
+++ b/apps/web/src/components/motion/CountUp.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { useEffect, useRef } from 'react';
+import { animate, useMotionValue, useReducedMotion } from 'motion/react';
+
+interface CountUpProps {
+  value: number;
+  duration?: number;
+  format?: (n: number) => string;
+  className?: string;
+}
+
+/** Count-up on mount: 0 → value over `duration`ms with --ease-out. Renders the
+ * final value immediately (no animation) when prefers-reduced-motion is set. */
+export function CountUp({ value, duration = 0.6, format = (n) => Math.round(n).toLocaleString('es-CO'), className }: CountUpProps) {
+  const nodeRef = useRef<HTMLSpanElement>(null);
+  const motionValue = useMotionValue(0);
+  const reducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    if (!nodeRef.current) return;
+
+    if (reducedMotion) {
+      nodeRef.current.textContent = format(value);
+      return;
+    }
+
+    const controls = animate(motionValue, value, {
+      duration,
+      ease: [0.16, 1, 0.3, 1], // --ease-out
+      onUpdate: (v) => {
+        if (nodeRef.current) nodeRef.current.textContent = format(v);
+      },
+    });
+    return () => controls.stop();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, reducedMotion]);
+
+  return <span ref={nodeRef} className={className}>{format(0)}</span>;
+}

--- a/apps/web/src/components/motion/index.tsx
+++ b/apps/web/src/components/motion/index.tsx
@@ -1,2 +1,3 @@
 export { FadeUp } from './FadeUp';
 export { Stagger } from './Stagger';
+export { CountUp } from './CountUp';


### PR DESCRIPTION
…sweep

New CountUp (apps/web/src/components/motion/CountUp.tsx): animates 0 -> value over 600ms with --ease-out via motion's animate()/ MotionValue, renders the final value directly under prefers-reduced-motion. Wired into the dashboard stat cards; the delta badge now fades in 150ms after the count-up starts.

PlatformBreakdownChart: bars grow from baseline (Recharts native animation, 400ms ease-out, 40ms stagger across series), segment colors move to --color-chart-1..4 in fixed order, and the card shell migrates to the surface/rounded-card tokens (was still raw gray-900).

BestTimesHeatmap: cells fade in with an 8ms-per-hour-column sweep (motion-safe: prefix auto-respects reduced motion, no JS needed), the color scale collapses to a single accent-tinted tone (was a 4-step indigo/70/50/40 opacity ladder) and the card migrates to tokens too.

Not implemented (documented gap): the PR-04 post-metric-history line/ area chart has no frontend component yet — only the backend endpoint exists (PR-04, this session) — so its pathLength-trace delta has nothing to attach to.